### PR TITLE
Add Vercel deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v20
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prod'
+          working-directory: .
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ Tech: Next.js 14 (App Router), React 18, Tailwind CSS, shadcn/ui.
 ### Styling
 - Tailwind configured via `tailwind.config.js` and `postcss.config.js`.
 - shadcn/ui components live in `components/ui/*` and use CSS variables defined in `app/globals.css`.
+
+## Deployment
+
+This project uses a GitHub Action workflow to deploy to [Vercel](https://vercel.com/) whenever changes are pushed to the `main` branch.
+To enable deployments, add the `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` secrets in your repository settings.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy Next.js app to Vercel on pushes to `main`
- document required Vercel secrets and workflow in README

## Testing
- `pnpm build` *(fails: w-22 class does not exist in app/globals.css)*

------
https://chatgpt.com/codex/tasks/task_e_6895d99d82088333ae201571f2380f4f