### PR TITLE
feat: extend spacing scale for image thumbnails

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -67,7 +67,7 @@
 .research-block { @apply bg-secondary border rounded-xl p-2.5; }
 .research-block .row { @apply flex gap-2; }
 
-.images-grid { @apply grid [grid-template-columns:repeat(auto-fill,88px)] gap-2 mt-2; }
+.images-grid { @apply grid [grid-template-columns:repeat(auto-fill,theme('spacing.22'))] gap-2 mt-2; }
 .image-thumb { @apply w-22 h-22 rounded-lg border bg-cover bg-center; }
 
 .main-pane { @apply overflow-hidden flex flex-col; }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -61,6 +61,9 @@ module.exports = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },
+      spacing: {
+        22: "5.5rem",
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
## Summary
- extend Tailwind spacing scale with `22` to support 88px utility classes
- use `w-22`/`h-22` and `theme('spacing.22')` for image thumbnails and grid layout

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6895d65dae2c8333b217adc760054749